### PR TITLE
✨ Improve boxcutter experimental parity

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -443,7 +443,7 @@ func run() error {
 	// create applier
 	var ctrlBuilderOpts []controllers.ControllerBuilderOption
 	var extApplier controllers.Applier
-
+	certProvider := getCertificateProvider()
 	if features.OperatorControllerFeatureGate.Enabled(features.BoxcutterRuntime) {
 		// TODO: add support for preflight checks
 		// TODO: better scheme handling - which types do we want to support?
@@ -454,14 +454,14 @@ func run() error {
 			RevisionGenerator: &applier.SimpleRevisionGenerator{
 				Scheme: mgr.GetScheme(),
 				BundleRenderer: &applier.RegistryV1BundleRenderer{
-					BundleRenderer: registryv1.Renderer,
+					BundleRenderer:      registryv1.Renderer,
+					CertificateProvider: certProvider,
 				},
 			},
 		}
 		ctrlBuilderOpts = append(ctrlBuilderOpts, controllers.WithOwns(&ocv1.ClusterExtensionRevision{}))
 	} else {
 		// now initialize the helmApplier, assigning the potentially nil preAuth
-		certProvider := getCertificateProvider()
 		extApplier = &applier.Helm{
 			ActionClientGetter: acg,
 			Preflights:         preflights,

--- a/config/components/base/experimental/kustomization.yaml
+++ b/config/components/base/experimental/kustomization.yaml
@@ -16,5 +16,6 @@ components:
 - ../../features/preflight-permissions
 - ../../features/apiv1-metas-handler
 - ../../features/helm-chart
+- ../../features/boxcutter-runtime
 # This one is downstream only, so we shant use it
 # - ../../features/webhook-provider-openshift-serviceca

--- a/config/components/features/boxcutter-runtime/cluster_role_binding.yaml
+++ b/config/components/features/boxcutter-runtime/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-controller-boxcutter-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: olmv1-system

--- a/config/components/features/boxcutter-runtime/kustomization.yaml
+++ b/config/components/features/boxcutter-runtime/kustomization.yaml
@@ -2,6 +2,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+ - cluster_role_binding.yaml
 patches:
  - target:
       kind: Deployment

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1968,6 +1968,7 @@ spec:
         - --feature-gates=SingleOwnNamespaceInstallSupport=true
         - --feature-gates=PreflightPermissions=true
         - --feature-gates=HelmChartSupport=true
+        - --feature-gates=BoxcutterRuntime=true
         - --catalogd-cas-dir=/var/certs
         - --pull-cas-dir=/var/certs
         - --tls-cert=/var/certs/tls.cert

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1702,6 +1702,21 @@ kind: ClusterRoleBinding
 metadata:
   annotations:
     olm.operatorframework.io/feature-set: experimental
+  name: operator-controller-boxcutter-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1934,6 +1934,7 @@ spec:
         - --feature-gates=SingleOwnNamespaceInstallSupport=true
         - --feature-gates=PreflightPermissions=true
         - --feature-gates=HelmChartSupport=true
+        - --feature-gates=BoxcutterRuntime=true
         - --catalogd-cas-dir=/var/certs
         - --pull-cas-dir=/var/certs
         - --tls-cert=/var/certs/tls.cert

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1702,6 +1702,21 @@ kind: ClusterRoleBinding
 metadata:
   annotations:
     olm.operatorframework.io/feature-set: experimental
+  name: operator-controller-boxcutter-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

3 separate commits that bring the boxcutter branch closer to being ready to merge into operator-controller's main branch:
1. Add support for the webhook support feature gate to the boxcutter code paths
2. Add boxcutter to the experimental release
3. Add a new boxcutter specific cluster-admin cluster role binding

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
